### PR TITLE
Removed describe as json

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Please answer the following questions in a markdown file called `Answers to tech
 2. What was the most useful feature that was added to the latest version of your chosen language? Please include a snippet of code that shows how you've used it.
 3. How would you track down a performance issue in production? Have you ever had to do this?
 4. How would you improve the Just Eat APIs that you just used?
-5. Please describe yourself using JSON.
 
 
 #### Thanks for your time, we look forward to hearing from you!


### PR DESCRIPTION
Removed requirement to describe as json as it could be interpreted as an invitation for candidates share personal details that should not be disclosed as part of the recruitment process 