### PR TITLE
Languages options refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ The task is to create an application that accepts an outcode as a parameter. The
 
 You can create the application as either a command line application, web application or mobile application in any of the following platforms
 
-- .NET (Full Framework or Core), PHP, Ruby, Python or JavaScript for web applications
-- .NET (Full Framework or Core), Ruby or Python for command line applications
+- .NET, Python or JavaScript/TypeScript (can use Angular/React/Vue.js) for web applications.
+- .NET or Python for command line applications
 - iOS, Android or Windows Mobile for mobile applications
 
 Think about the type of work you would like to do at Just Eat and **choose an appropriate application type and platform**.


### PR DESCRIPTION
* PHP & Ruby can be used but given we have very little talent to assess such submission this should be pre-agreed on a case by case basis and not an option by default.
* Given .NET is finally converging I don't think we should explicitly call out full framework/core any more
* Add TypeScript as an option
* Mention modern web frameworks as an option.